### PR TITLE
Fix view path  & tax amount on cart update

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -85,6 +85,17 @@ class CartController extends Controller
 
         Cart::update($slug, $qty);
 
+        $productModel = $this->repository->findBySlug($slug);
+        $isTaxEnabled = $this->configurationRepository->getValueByKey('tax_enabled');
+
+        if ($isTaxEnabled && $productModel->is_taxable) {
+            $percentage = $this->configurationRepository->getValueByKey('tax_percentage');
+            $taxAmount = ($percentage * $productModel->price / 100);
+
+            Cart::hasTax(true);
+            Cart::updateProductTax($slug, $taxAmount);
+        }
+        
         return redirect()->back();
     }
 

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -53,7 +53,7 @@ class CartController extends Controller
 
         Cart::add($slug, $qty, $attribute);
 
-        $this->_setTaxAmont($slug);
+        $this->_setTaxAmount($slug);
 
         return redirect()->back()->with('notificationText', 'Product Added to Cart Successfully!');
     }
@@ -76,7 +76,7 @@ class CartController extends Controller
 
         Cart::update($slug, $qty);
 
-        $this->_setTaxAmont($slug);
+        $this->_setTaxAmount($slug);
 
         return redirect()->back();
     }
@@ -87,7 +87,7 @@ class CartController extends Controller
         return redirect()->back()->with('notificationText', 'Product has been remove from Cart!');
     }
 
-    private function _setTaxAmont($slug)
+    private function _setTaxAmount($slug)
     {
         $productModel = $this->repository->findBySlug($slug);
         $isTaxEnabled = $this->configurationRepository->getValueByKey('tax_enabled');

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -23,6 +23,8 @@ class CartController extends Controller
 
     public function __construct(ProductInterface $repository, ConfigurationInterface $configRep)
     {
+        parent::__construct();
+
         $this->repository = $repository;
         $this->configurationRepository = $configRep;
     }

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -53,16 +53,7 @@ class CartController extends Controller
 
         Cart::add($slug, $qty, $attribute);
 
-        $productModel = $this->repository->findBySlug($slug);
-        $isTaxEnabled = $this->configurationRepository->getValueByKey('tax_enabled');
-
-        if ($isTaxEnabled && $productModel->is_taxable) {
-            $percentage = $this->configurationRepository->getValueByKey('tax_percentage');
-            $taxAmount = ($percentage * $productModel->price / 100);
-
-            Cart::hasTax(true);
-            Cart::updateProductTax($slug, $taxAmount);
-        }
+        $this->_setTaxAmont($slug);
 
         return redirect()->back()->with('notificationText', 'Product Added to Cart Successfully!');
     }
@@ -85,6 +76,19 @@ class CartController extends Controller
 
         Cart::update($slug, $qty);
 
+        $this->_setTaxAmont($slug);
+
+        return redirect()->back();
+    }
+
+    public function destroy($slug)
+    {
+        Cart::destroy($slug);
+        return redirect()->back()->with('notificationText', 'Product has been remove from Cart!');
+    }
+
+    private function _setTaxAmont($slug)
+    {
         $productModel = $this->repository->findBySlug($slug);
         $isTaxEnabled = $this->configurationRepository->getValueByKey('tax_enabled');
 
@@ -95,13 +99,5 @@ class CartController extends Controller
             Cart::hasTax(true);
             Cart::updateProductTax($slug, $taxAmount);
         }
-        
-        return redirect()->back();
-    }
-
-    public function destroy($slug)
-    {
-        Cart::destroy($slug);
-        return redirect()->back()->with('notificationText', 'Product has been remove from Cart!');
     }
 }

--- a/app/Http/Controllers/CategoryViewController.php
+++ b/app/Http/Controllers/CategoryViewController.php
@@ -16,6 +16,8 @@ class CategoryViewController extends Controller
 
     public function __construct(CategoryInterface $repository)
     {
+        parent::__construct();
+
         $this->repository = $repository;
     }
 

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -33,6 +33,8 @@ class OrderController extends Controller
      */
     public function __construct(ConfigurationInterface $rep)
     {
+        parent::__construct();
+
         $this->repository = $rep;
     }
 

--- a/app/Http/Controllers/ProductViewController.php
+++ b/app/Http/Controllers/ProductViewController.php
@@ -24,6 +24,8 @@ class ProductViewController extends Controller
         ProductInterface $repository,
         ProductDownloadableUrlInterface $downRep
         ) {
+        parent::__construct();
+
         $this->repository = $repository;
         $this->downRep = $downRep;
     }


### PR DESCRIPTION
In some controllers the __construct() parent is not called. Because of this, if the theme was changed, the Theme View Path is not set and code return exception.

Fix tax amount on cart update.