### PR TITLE
Use compact() for view data

### DIFF
--- a/app/Http/Composers/NavComposer.php
+++ b/app/Http/Composers/NavComposer.php
@@ -34,6 +34,6 @@ class NavComposer
             $menus = $this->menuGroupRepository->getTreeByIdentifier('main-menu');
         }
 
-        $view->with('menus', $menus);
+        $view->with(compact('menus'));
     }
 }

--- a/app/Http/Controllers/Account/AddressController.php
+++ b/app/Http/Controllers/Account/AddressController.php
@@ -46,7 +46,7 @@ class AddressController extends Controller
         $userAddresses = $this->addressRepository->getByUserId(Auth::user()->id);
         
         return view('account.address.index')
-            ->with('userAddresses', $userAddresses);
+            ->with(compact('userAddresses'));
     }
 
     /**
@@ -60,8 +60,7 @@ class AddressController extends Controller
         $countryOptions = $this->countryRepository->options();
         
         return view('account.address.create')
-            ->with('countryOptions', $countryOptions)
-            ->with('typeOptions', $typeOptions);
+            ->with(compact('countryOptions', 'typeOptions'));
     }
 
     /**
@@ -99,9 +98,7 @@ class AddressController extends Controller
         $countryOptions = $this->countryRepository->options();
 
         return view('account.address.edit')
-            ->with('address', $address)
-            ->with('countryOptions', $countryOptions)
-            ->with('typeOptions', $typeOptions);
+            ->with(compact('address', 'countryOptions', 'typeOptions'));
     }
 
     /**

--- a/app/Http/Controllers/Account/OrderController.php
+++ b/app/Http/Controllers/Account/OrderController.php
@@ -36,7 +36,7 @@ class OrderController extends Controller
         $userOrders = $this->orderRepository->findByUserId(Auth::user()->id);
         
         return view('account.order.index')
-            ->with('userOrders', $userOrders);
+            ->with(compact('userOrders'));
     }
 
 
@@ -49,6 +49,6 @@ class OrderController extends Controller
     public function show(Order $order)
     {
         return view('account.order.show')
-            ->with('order', $order);
+            ->with(compact('order'));
     }
 }

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -17,12 +17,11 @@ class CartController extends Controller
      */
     public function addToCart(CartRequest $request)
     {
-        list ($status, $message) = Cart::add($request->get('slug'), $request->get('qty'), $request->get('attributes'));
+        list ($success, $message) = Cart::add($request->get('slug'), $request->get('qty'), $request->get('attributes'));
 
         return redirect()
             ->back()
-            ->with('success', $status)
-            ->with('message', $message);
+            ->with(compact('success', 'message'));
     }
 
     /**
@@ -33,6 +32,6 @@ class CartController extends Controller
     {
         $cartProducts = Cart::all();
 
-        return view('cart.show')->with('cartProducts', $cartProducts);
+        return view('cart.show')->with(compact('cartProducts'));
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -42,8 +42,6 @@ class CategoryController extends Controller
         $categoryFilters = $this->categoryFilterRepository->findByCategoryId($category->id);
         
         return view('category.show')
-            ->with('categoryFilters', $categoryFilters)
-            ->with('categoryProducts', $categoryProducts)
-            ->with('category', $category);
+            ->with(compact('categoryFilters', 'categoryProducts', 'category'));
     }
 }

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -50,9 +50,6 @@ class CheckoutController extends Controller
         $countryOptions = $this->CountryRepository->options();
 
         return view('checkout.show')
-            ->with('shippingOptions', $shippingOptions)
-            ->with('paymentOptions', $paymentOptions)
-            ->with('addresses', $addresses)
-            ->with('countryOptions', $countryOptions);
+            ->with(compact('shippingOptions', 'paymentOptions', 'addresses', 'countryOptions'));
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -37,6 +37,6 @@ class HomeController extends Controller
         }
         
         return view('home')
-            ->with('products', $products);
+            ->with(compact('products'));
     }
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -30,6 +30,6 @@ class ProductController extends Controller
         $product->images;
 
         return view('product.show')
-            ->with('product', $product);
+            ->with(compact('product'));
     }
 }


### PR DESCRIPTION
Since the keys of data passed to views share the same name as their respective variables, we can use the [compact](https://www.php.net/manual/en/function.compact.php) function, thus avoiding repeating the name twice in the code.

## Description
In the code below, variables are being passed to the view using the same name as key:
<!--- Describe your changes in detail -->
```php
return view('account.address.edit')
    ->with('address', $address)
    ->with('countryOptions', $countryOptions)
    ->with('typeOptions', $typeOptions);
```
We can then use compact while keeping the same result:
```php
return view('account.address.edit')
    ->with(compact('address', 'countryOptions', 'typeOptions'));
```

## Motivation and Context
This change aims to make the code simpler and easier to maintain, with the advantage of ensuring that we create variables with the name they should have.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Refactor.